### PR TITLE
fix: typo in Python module name in module docstring

### DIFF
--- a/fava_plugins/split_income.py
+++ b/fava_plugins/split_income.py
@@ -5,7 +5,7 @@ transactions. The pre-tax transaction will be tagged, allowing you to filter
 them out, leaving you only with your net income. The plugin can be configured
 as follows:
 
-    plugin "fava-plugins.split_income" "{
+    plugin "fava_plugins.split_income" "{
         'income': 'Income:Work',
         'net_income': 'Income:Net',
         'taxes': 'Expenses:Taxes',


### PR DESCRIPTION
I might be mistaken, but I think that the `-` has to be `_` for the import to work. Here is my testing:
```
[I] ⋊> ~/my-beancount on mainline ⨯ python                                                                                          (beancount) 22:30:18
Python 3.11.5 (main, Sep 11 2023, 08:19:27) [Clang 14.0.6 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import importlib
>>> importlib.import_module('fava_plugins.split_income')
<module 'fava_plugins.split_income' from '/Users/williamdavies/opt/miniconda3/envs/beancount/lib/python3.11/site-packages/fava_plugins/split_income.py'>
>>> importlib.import_module('fava-plugins.split_income')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/williamdavies/opt/miniconda3/envs/beancount/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1126, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1140, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'fava-plugins'
>>> importlib.import_module('fava-plugins')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/williamdavies/opt/miniconda3/envs/beancount/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1140, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'fava-plugins'
>>> importlib.import_module('fava_plugins')
<module 'fava_plugins' from '/Users/williamdavies/opt/miniconda3/envs/beancount/lib/python3.11/site-packages/fava_plugins/__init__.py'>
```
Please do let me know if I'm wrong! Otherwise, updating the docstring will help others avoid the head-scratching I just did :)